### PR TITLE
Fb uapi screeninfo

### DIFF
--- a/helios/drivers/fb.c
+++ b/helios/drivers/fb.c
@@ -7,15 +7,16 @@
 #include "kernel/semaphores.h"
 #include "lib/log.h"
 #include "lib/string.h"
+#include "uapi/helios/fb.h"
 
 #include <uapi/helios/errno.h>
 
-struct fb_device fbdev = { 0 };
+struct fb_device g_fbdev = { 0 };
 
 static struct file_ops fb_fops = {
 	.read = nullptr,
 	.write = fb_write,
-	.ioctl = nullptr,
+	.ioctl = fb_ioctl,
 	.mmap = nullptr,
 	.open = nullptr,
 };
@@ -31,18 +32,18 @@ void fb_init()
 	struct limine_framebuffer* fb =
 		framebuffer_request.response->framebuffers[0];
 
-	sem_init(&fbdev.sem, 1);
+	sem_init(&g_fbdev.sem, 1);
 
-	fbdev.width = (u32)fb->width;
-	fbdev.height = (u32)fb->height;
-	fbdev.pitch = (u32)fb->pitch;
-	fbdev.bpp = (u32)fb->bpp;
-	fbdev.format = FB_FMT_XRGB8888; // TODO: support more formats
+	g_fbdev.width = (u32)fb->width;
+	g_fbdev.height = (u32)fb->height;
+	g_fbdev.pitch = (u32)fb->pitch;
+	g_fbdev.bpp = (u32)fb->bpp;
+	g_fbdev.format = FB_FMT_XRGB8888; // TODO: support more formats
 
-	fbdev.vram_paddr = HHDM_TO_PHYS(fb->address);
-	fbdev.vram_len = fb->pitch * fb->height;
+	g_fbdev.vram_paddr = HHDM_TO_PHYS(fb->address);
+	g_fbdev.vram_len = fb->pitch * fb->height;
 
-	fbdev.caps = 0;
+	g_fbdev.caps = 0;
 
 	/*
 	 * Now we init the fb character device
@@ -55,18 +56,18 @@ void fb_init()
 		panic("Cannot continue without framebuffer");
 	}
 
-	fbdev.cdev.name = strdup("fb");
-	if (!fbdev.cdev.name) {
+	g_fbdev.cdev.name = strdup("fb");
+	if (!g_fbdev.cdev.name) {
 		log_error("Failed to allocate fb chrdev name");
 		panic("Cannot continue without framebuffer");
 	}
 
-	fbdev.cdev.base = base;
-	fbdev.cdev.count = 1;
-	fbdev.cdev.fops = &fb_fops;
-	fbdev.cdev.drvdata = &fbdev;
+	g_fbdev.cdev.base = base;
+	g_fbdev.cdev.count = 1;
+	g_fbdev.cdev.fops = &fb_fops;
+	g_fbdev.cdev.drvdata = &g_fbdev;
 
-	chrdev_add(&fbdev.cdev, fbdev.cdev.base, fbdev.cdev.count);
+	chrdev_add(&g_fbdev.cdev, g_fbdev.cdev.base, g_fbdev.cdev.count);
 
 	struct vfs_superblock* devfs_sb = vfs_get_sb("/dev");
 	if (!devfs_sb) {
@@ -75,8 +76,8 @@ void fb_init()
 	}
 
 	devfs_map_name(devfs_sb,
-		       fbdev.cdev.name,
-		       fbdev.cdev.base,
+		       g_fbdev.cdev.name,
+		       g_fbdev.cdev.base,
 		       FILETYPE_CHAR_DEV,
 		       0666,
 		       0);
@@ -84,19 +85,20 @@ void fb_init()
 	log_info("Framebuffer initialized");
 }
 
-ssize_t
-fb_write(struct vfs_file* file, const char* buffer, size_t count, off_t* offset)
+ssize_t fb_write(struct vfs_file* file,
+		 const char __user* buffer,
+		 size_t count,
+		 off_t* offset)
 {
-	// TODO: Get fbdev from cdev->drvdata
-	(void)file;
 	(void)offset;
 
-	if (count > fbdev.vram_len) {
-		count = fbdev.vram_len;
+	struct fb_device* fbdev = file->private_data;
+
+	if (count > fbdev->vram_len) {
+		count = fbdev->vram_len;
 	}
-	// TODO: Should probably map the vram_paddr in the process instead of
-	// straight hhdm
-	memcpy((void*)PHYS_TO_HHDM(fbdev.vram_paddr), buffer, count);
+
+	copy_from_user((void*)PHYS_TO_HHDM(fbdev->vram_paddr), buffer, count);
 
 	return (ssize_t)count;
 }
@@ -110,4 +112,35 @@ int fb_mmap(struct vfs_file* file, void* addr, size_t len, int prot, off_t off)
 	(void)off;
 
 	return -ENOSYS;
+}
+
+static void fb_get_screeninfo(struct fb_device* fbdev,
+			      struct fb_screeninfo* info)
+{
+	info->width = fbdev->width;
+	info->height = fbdev->height;
+	info->pitch = fbdev->pitch;
+	info->bpp = fbdev->bpp;
+	info->format = (uint32_t)fbdev->format;
+	info->caps = fbdev->caps;
+	info->vram_len = fbdev->vram_len;
+}
+
+int fb_ioctl(struct vfs_file* file, unsigned long request, void __user* arg)
+{
+	kassert(file != nullptr);
+
+	struct fb_device* fbdev = file->private_data;
+	kassert(fbdev != nullptr);
+
+	switch (request) {
+	case FBIOGET_SCREENINFO: {
+		struct fb_screeninfo info = { 0 };
+		fb_get_screeninfo(fbdev, &info);
+		return (int)copy_to_user(arg,
+					 &info,
+					 sizeof(struct fb_screeninfo));
+	}
+	default: return -ENOTTY; // Invalid request
+	}
 }

--- a/helios/fs/devfs/devfs.c
+++ b/helios/fs/devfs/devfs.c
@@ -51,7 +51,7 @@ static struct file_ops devfs_fops = {
 	.readdir = devfs_readdir,
 };
 
-static struct sb_ops devfs_sb_ops = {};
+static struct sb_ops devfs_sb_ops = { };
 
 /*******************************************************************************
  * Private Function Prototypes
@@ -471,7 +471,6 @@ int devnode_open(struct vfs_inode* inode, struct vfs_file* file)
 		return rc;
 	}
 
-	inode->fops = fops;
 	file->fops = fops;
 	file->private_data = drv;
 

--- a/helios/include/drivers/fb.h
+++ b/helios/include/drivers/fb.h
@@ -3,20 +3,9 @@
 
 #include "drivers/device.h"
 #include "kernel/semaphores.h"
+#include "kernel/uaccess.h"
 
-// Not sure what I actually support, but oh well
-enum fb_format {
-	FB_FMT_XRGB8888 = 0, // 32bpp, little-endian, X R G B
-};
-
-/* Capabilities bitmask for feature discovery. */
-enum fb_caps {
-	FB_CAP_MMAP = 1u << 0,	     // supports mmap of VRAM
-	FB_CAP_PAN = 1u << 1,	     // y/x panning or buffer index
-	FB_CAP_VBLANK_IRQ = 1u << 2, // can wait for vsync/poll
-	FB_CAP_SET_MODE = 1u << 3,   // can change resolution/format
-	FB_CAP_FLUSH_RECT = 1u << 4, // needs/accepts explicit flush
-};
+#include <uapi/helios/fb.h>
 
 struct fb_device {
 	u32 width; // visible pixels
@@ -39,6 +28,8 @@ struct fb_device {
 void fb_init();
 
 ssize_t fb_write(struct vfs_file* file,
-		 const char* buffer,
+		 const char __user* buffer,
 		 size_t count,
 		 off_t* offset);
+
+int fb_ioctl(struct vfs_file* file, unsigned long request, void __user* arg);

--- a/helios/include/fs/vfs.h
+++ b/helios/include/fs/vfs.h
@@ -144,7 +144,7 @@ struct file_ops {
 			size_t count,
 			off_t* offset);
 	ssize_t (*write)(struct vfs_file* file,
-			 const char* buffer,
+			 const char __user* buffer,
 			 size_t count,
 			 off_t* offset);
 

--- a/helios/include/uapi/helios/fb.h
+++ b/helios/include/uapi/helios/fb.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2026 Dylan Parks
+ *
+ * This file is part of HeliOS
+ *
+ * HeliOS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef _UAPI_HELIOS_FB_H
+#define _UAPI_HELIOS_FB_H 1
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct fb_screeninfo {
+	uint32_t width;	   /* visible pixels */
+	uint32_t height;
+	uint32_t pitch;	   /* bytes per scanline */
+	uint32_t bpp;	   /* bits per pixel */
+	uint32_t format;   /* enum fb_format */
+	uint32_t caps;	   /* enum fb_caps bitmask */
+	uint64_t vram_len; /* total mappable bytes */
+};
+
+// Not sure what I actually support, but oh well
+enum fb_format {
+	FB_FMT_XRGB8888 = 0, // 32bpp, little-endian, X R G B
+};
+
+/* Capabilities bitmask for feature discovery. */
+enum fb_caps {
+	FB_CAP_MMAP = 1u << 0,	     // supports mmap of VRAM
+	FB_CAP_PAN = 1u << 1,	     // y/x panning or buffer index
+	FB_CAP_VBLANK_IRQ = 1u << 2, // can wait for vsync/poll
+	FB_CAP_SET_MODE = 1u << 3,   // can change resolution/format
+	FB_CAP_FLUSH_RECT = 1u << 4, // needs/accepts explicit flush
+};
+
+#define FBIOGET_SCREENINFO 0x4600
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _UAPI_HELIOS_FB_H */

--- a/helios/include/uapi/helios/fb.h
+++ b/helios/include/uapi/helios/fb.h
@@ -50,6 +50,16 @@ enum fb_caps {
 	FB_CAP_FLUSH_RECT = 1u << 4, // needs/accepts explicit flush
 };
 
+static inline const char* __get_fb_format_name(uint32_t fmt)
+{
+	enum fb_format _fmt = (enum fb_format)fmt;
+
+	switch (_fmt) {
+	case FB_FMT_XRGB8888: return "XRGB8888";
+	default:	      return "UNKNOWN";
+	}
+}
+
 #define FBIOGET_SCREENINFO 0x4600
 
 #ifdef __cplusplus

--- a/userspace/test_fb/Makefile
+++ b/userspace/test_fb/Makefile
@@ -1,0 +1,44 @@
+include $(HELIOS_ROOT)/toolchain.mk
+
+# NOTE: REPLACE THESE WITH YOUR APPLICATION NAME
+APP      := test_fb
+APP_ELF  := $(APP).elf
+BUILDDIR ?= build
+
+SRCS  := $(sort $(shell find * -type f \( -name "*.c" \
+				       -o -name "*.asm" \
+				       -o -name "*.S" \)))
+
+OBJS  := $(patsubst %.c,$(BUILDDIR)/%.o,$(filter %.c,$(SRCS))) \
+	 $(patsubst %.S,$(BUILDDIR)/%.o,$(filter %.S,$(SRCS))) \
+	 $(patsubst %.asm,$(BUILDDIR)/%.o,$(filter %.asm,$(SRCS)))
+
+APP_LDLIBS :=
+
+.PHONY: all install clean
+all: $(APP_ELF)
+
+$(BUILDDIR)/%.o: %.c
+	@mkdir -p $(@D)
+	@$(CC) -MD -c $< -o $@ $(US_CFLAGS) $(US_CPPFLAGS)
+
+$(BUILDDIR)/%.o: %.S
+	@mkdir -p $(@D)
+	@$(CC) -MD -c $< -o $@ $(US_CFLAGS) $(US_CPPFLAGS)
+
+$(BUILDDIR)/%.o: %.asm
+	@mkdir -p $(@D)
+	@$(NASM) $(NASMFLAGS) $< -o $@
+
+# Link order: CRT prologue, objects, libs, CRT epilogue
+$(APP_ELF): $(OBJS) $(LIBC_DEPS)
+	@$(CC) $(US_LDFLAGS) $(CRT0) $(CRTI) $(OBJS) -o $@ $(US_LDLIBS) $(APP_LDLIBS) $(CRTN)
+
+install: $(APP_ELF)
+	@mkdir -p $(SYSROOT)/usr/bin
+	@cp $(APP_ELF) $(SYSROOT)/usr/bin/
+
+clean:
+	-@rm -rf $(BUILDDIR) $(APP_ELF)
+
+-include $(OBJS:.o=.d)

--- a/userspace/test_fb/main.c
+++ b/userspace/test_fb/main.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <fcntl.h>
 #include <helios/fb.h>
 #include <stdio.h>
@@ -7,10 +6,6 @@
 
 int main(void)
 {
-	int ok = 1;
-
-	// ENOTTY: open something real that has no .ioctl handler.
-	// "/" is guaranteed to exist and isn't a chardev.
 	int fd = open("/dev/fb", O_RDONLY);
 	if (fd < 0) {
 		perror("open");
@@ -35,5 +30,5 @@ int main(void)
 
 	close(fd);
 
-	return ok ? 0 : 1;
+	return 0;
 }

--- a/userspace/test_fb/main.c
+++ b/userspace/test_fb/main.c
@@ -1,0 +1,39 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <helios/fb.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+int main(void)
+{
+	int ok = 1;
+
+	// ENOTTY: open something real that has no .ioctl handler.
+	// "/" is guaranteed to exist and isn't a chardev.
+	int fd = open("/dev/fb", O_RDONLY);
+	if (fd < 0) {
+		perror("open");
+		return 1;
+	}
+
+	struct fb_screeninfo info = { 0 };
+	int res = ioctl(fd, FBIOGET_SCREENINFO, &info);
+	if (res < 0) {
+		perror("ioctl");
+		return 1;
+	}
+
+	printf("FBIOGET_SCREENINFO:\n");
+	printf("    Width: %u\n", info.width);
+	printf("    Height: %u\n", info.height);
+	printf("    Pitch: %u\n", info.pitch);
+	printf("    BPP: %u\n", info.bpp);
+	printf("    Format: %s\n", __get_fb_format_name(info.format));
+	printf("    Capabilities: 0x%x\n", info.caps);
+	printf("    VRAM Length: %zu\n", info.vram_len);
+
+	close(fd);
+
+	return ok ? 0 : 1;
+}


### PR DESCRIPTION
Adds `fb_ioctl` and `FBIOGET_SCREENINFO` alongside a test userspace program which calls it.
Another important change is a change to devfs. During `devnode_open` I no longer overwrite `inode->fops` since that is supposed to be a "default" fops for new opens (it also caused a fault when opening `/dev/fb` multiple times)..